### PR TITLE
Globhfs directories

### DIFF
--- a/src/core/cascading/flow/Flow.java
+++ b/src/core/cascading/flow/Flow.java
@@ -116,6 +116,8 @@ public class Flow implements Runnable
   private Map<String, Tap> traps;
   /** Field preserveTemporaryFiles */
   private boolean preserveTemporaryFiles = false;
+  /** Field skipModifiedCheckOnReplaceOrUpdate */
+  private boolean skipModifiedCheckOnReplaceOrUpdate = true;
   /** Field stopJobsOnExit */
   protected boolean stopJobsOnExit = true;
 
@@ -141,6 +143,14 @@ public class Flow implements Runnable
   private transient ExecutorService executor;
   /** Field shutdownHook */
   private transient Thread shutdownHook;
+
+  public void setSkipModifiedCheckOnReplaceOrUpdate(boolean check) {
+      skipModifiedCheckOnReplaceOrUpdate = check;
+  }
+
+  public boolean getSkipModifiedCheckOnReplaceOrUpdate() {
+      return skipModifiedCheckOnReplaceOrUpdate;
+  }
 
   /**
    * Property preserveTemporaryFiles forces the Flow instance to keep any temporary intermediate data sets. Useful
@@ -665,7 +675,7 @@ public class Flow implements Runnable
 
     for( Tap sink : sinks.values() )
       {
-      if( sink.isReplace() || sink.isUpdate() )
+      if( skipModifiedCheckOnReplaceOrUpdate && (sink.isReplace() || sink.isUpdate()) )
         sinkModified = -1L;
       else
         {

--- a/src/core/cascading/tap/GlobHfs.java
+++ b/src/core/cascading/tap/GlobHfs.java
@@ -54,6 +54,8 @@ public class GlobHfs extends MultiSourceTap
   private String pathPattern;
   /** Field pathFilter */
   private PathFilter pathFilter;
+  /** Field includeOnlyDirectories */
+  private boolean includeOnlyDirectories;
 
   /**
    * Constructor GlobHfs creates a new GlobHfs instance.
@@ -64,7 +66,20 @@ public class GlobHfs extends MultiSourceTap
   @ConstructorProperties({"scheme", "pathPattern"})
   public GlobHfs( Scheme scheme, String pathPattern )
     {
-    this( scheme, pathPattern, null );
+    this( scheme, pathPattern, null, false );
+    }
+
+  /**
+   * Constructor GlobHfs creates a new GlobHfs instance.
+   *
+   * @param scheme             of type Scheme
+   * @param pathPattern        of type String
+   * @param includeOnlyDirectories of type boolean
+   */
+  @ConstructorProperties({"scheme", "pathPattern"})
+  public GlobHfs( Scheme scheme, String pathPattern, boolean includeOnlyDirectories)
+    {
+    this( scheme, pathPattern, null, includeOnlyDirectories );
     }
 
   /**
@@ -74,12 +89,26 @@ public class GlobHfs extends MultiSourceTap
    * @param pathPattern of type String
    * @param pathFilter  of type PathFilter
    */
-  @ConstructorProperties({"scheme", "pathPattern", "pathFilter"})
   public GlobHfs( Scheme scheme, String pathPattern, PathFilter pathFilter )
+    {
+      this( scheme, pathPattern, null, false );
+    }
+
+  /**
+   * Constructor GlobHfs creates a new GlobHfs instance.
+   *
+   * @param scheme             of type Scheme
+   * @param pathPattern        of type String
+   * @param pathFilter         of type PathFilter
+   * @param includeOnlyDirectories of type boolean
+   */
+  @ConstructorProperties({"scheme", "pathPattern", "pathFilter"})
+  public GlobHfs( Scheme scheme, String pathPattern, PathFilter pathFilter, boolean includeOnlyDirectories )
     {
     super( scheme );
     this.pathPattern = pathPattern;
     this.pathFilter = pathFilter;
+    this.includeOnlyDirectories = includeOnlyDirectories;
     }
 
   @Override
@@ -120,7 +149,7 @@ public class GlobHfs extends MultiSourceTap
 
     for( int i = 0; i < statusList.length; i++ )
       {
-      if( statusList[ i ].isDir() || statusList[ i ].getLen() != 0 )
+      if( (includeOnlyDirectories && statusList[ i ].isDir()) || ( !includeOnlyDirectories && statusList[ i ].getLen() != 0 ) )
         notEmpty.add( new Hfs( getScheme(), statusList[ i ].getPath().toString() ) );
       }
 

--- a/src/core/cascading/tap/GlobHfs.java
+++ b/src/core/cascading/tap/GlobHfs.java
@@ -120,7 +120,7 @@ public class GlobHfs extends MultiSourceTap
 
     for( int i = 0; i < statusList.length; i++ )
       {
-      if( statusList[ i ].getLen() != 0 )
+      if( statusList[ i ].isDir() || statusList[ i ].getLen() != 0 )
         notEmpty.add( new Hfs( getScheme(), statusList[ i ].getPath().toString() ) );
       }
 

--- a/src/core/cascading/tap/GlobHfs.java
+++ b/src/core/cascading/tap/GlobHfs.java
@@ -91,7 +91,7 @@ public class GlobHfs extends MultiSourceTap
    */
   public GlobHfs( Scheme scheme, String pathPattern, PathFilter pathFilter )
     {
-      this( scheme, pathPattern, null, false );
+      this( scheme, pathPattern, pathFilter, false );
     }
 
   /**


### PR DESCRIPTION
Here's a small patch to have GlobHfs accept directories as child taps. I'm not sure if you want this be the a common behavior, but here's a use case. given the following file structure:
/date=2010-10-04/hour=00/
/date=2010-10-04/hour=01/
/date=2010-10-04/hour=.../
/date=2010-10-04/hour=22/
/date=2010-10-04/hour=23/

It'll allow the following to source those hour directories taps with the following statement:
GlobHfs inTap = new GlobHfs(new MyScheme(), "/date=2010-10-04/*");

Maybe to prevent compatibility issues, create a DirectoryGlobHfs instead? Or possibly a new GlobHfs constructor that enables globbing directories?
