### PR TITLE
Reduce size of serialized MultiInputSplit object

### DIFF
--- a/src/core/cascading/tap/hadoop/MultiInputSplit.java
+++ b/src/core/cascading/tap/hadoop/MultiInputSplit.java
@@ -65,6 +65,13 @@ public class MultiInputSplit implements InputSplit, JobConfigurable
     {
     this.inputSplit = inputSplit;
     this.config = config;
+
+    // reduce size of config map
+    if((this.inputSplit instanceof FileSplit)
+            && ((FileSplit) this.inputSplit).getPath() != null
+            && (this.config.containsKey("mapred.input.dir")) ) {
+        this.config.put("mapred.input.dir", ((FileSplit) this.inputSplit).getPath().toString());
+    }
     }
 
   public MultiInputSplit()


### PR DESCRIPTION
This patch significantly reduces the size of the serialized MultiInputSplit object in cases where you have lots of input files. In my test with a job that had 10K input files, the JobTracker memory usage barely went up relative to baseline, compared to 12 GB jump with the original code.

I've tested it against 0.20-based hadoop cluster on jobs with both single and multiple sources. I've only tested with file based taps, since that's all have available to me.
