### PR TITLE
Fixed an issue wherein writing all fields to a TemplateTap resulted in o...

### DIFF
--- a/src/core/cascading/tap/BaseTemplateTap.java
+++ b/src/core/cascading/tap/BaseTemplateTap.java
@@ -385,7 +385,7 @@ public abstract class BaseTemplateTap<Config, Output> extends SinkTap<Config, Ou
 
     public Fields getSinkFields()
       {
-      if( pathFields == null )
+      if( pathFields == null || scheme.getSinkFields().isAll() )
         return scheme.getSinkFields();
 
       return Fields.merge( scheme.getSinkFields(), pathFields );


### PR DESCRIPTION
...nly one field being sent to the parent

This is a small fix for a bug that we started observing when we upgraded to Cascalog 1.9.

The bug is visible when you wrap a TemplateTap around an output tap whose field set is Fields.ALL. If you do this, only the template pattern fields are written, since Fields.ALL is erased inside Fields.merge().
