### PR TITLE
Fix NPE in HadoopUtil.PlatformInfo when manifest is missing attributes

### DIFF
--- a/cascading-hadoop/src/main/java/cascading/flow/hadoop/util/HadoopUtil.java
+++ b/cascading-hadoop/src/main/java/cascading/flow/hadoop/util/HadoopUtil.java
@@ -492,7 +492,7 @@ public class HadoopUtil
     if( attributes == null )
       {
       LOG.debug( "unable to get Hadoop manifest attributes" );
-      new PlatformInfo( "Hadoop", null, null );
+      return new PlatformInfo( "Hadoop", null, null );
       }
 
     String vendor = attributes.getValue( "Implementation-Vendor" );


### PR DESCRIPTION
Ran into this issue on a new Cascading project -- I expected it to fail, but not with an NPE here. Tracked it down to this, and it looks like we should be returning this new PlatformInfo to avoid throwing an NPE on the line immediately following.
