### PR TITLE
charsetName name hiding fix in TextDelimited.java

### DIFF
--- a/cascading-hadoop/src/main/java/cascading/scheme/hadoop/TextDelimited.java
+++ b/cascading-hadoop/src/main/java/cascading/scheme/hadoop/TextDelimited.java
@@ -97,8 +97,6 @@ public class TextDelimited extends TextLine
   private boolean skipHeader;
   private final boolean writeHeader;
 
-  private String charsetName = DEFAULT_CHARSET;
-
   /**
    * Constructor TextDelimited creates a new TextDelimited instance sourcing {@link Fields#UNKNOWN}, sinking
    * {@link Fields#ALL} and using TAB as the default delimiter.


### PR DESCRIPTION
I ran into this bug while using charsets for the first time in cascading.

I believe the bug was introduced in https://github.com/cwensel/cascading/commit/c77484d7ff655642321ef15dda2877b90dde1e86

I do not think there are tests for the character set, but I have run the entire test suite on cascading-hadoop after this change and they pass.
