### PR TITLE
Improved DOT print

### DIFF
--- a/cascading-core/build.gradle
+++ b/cascading-core/build.gradle
@@ -22,6 +22,7 @@ dependencies {
   compile group: 'thirdparty', name: 'jgrapht-jdk1.6', version: '0.8.1'
   compile group: 'riffle', name: 'riffle', version: '0.1-dev'
   compile group: 'org.codehaus.janino', name: 'janino', version: '2.6.1'
+  compile group: 'commons-lang', name: 'commons-lang', version: '2.3'
 
   // this prevents a transitive dependency until it is required downstream
   providedCompile group: 'org.slf4j', name: 'slf4j-api', version: '1.6.1'

--- a/cascading-core/src/main/java/cascading/flow/planner/ElementGraph.java
+++ b/cascading-core/src/main/java/cascading/flow/planner/ElementGraph.java
@@ -478,17 +478,18 @@ public class ElementGraph extends SimpleDirectedGraph<FlowElement, Scope>
         public String getVertexName( FlowElement object )
           {
           if( object instanceof Tap || object instanceof Extent )
-            return object.toString().replaceAll( "\"", "\'" );
+            return Util.wrapWord(object.toString().replaceAll("\"", "\'"));
 
           Scope scope = graph.outgoingEdgesOf( object ).iterator().next();
 
-          return ( (Pipe) object ).print( scope ).replaceAll( "\"", "\'" );
+          return Util.wrapWord((( (Pipe) object ).print( scope ).replaceAll( "\"", "\'" )));
           }
         }, new EdgeNameProvider<Scope>()
         {
         public String getEdgeName( Scope object )
           {
-          return object.toString().replaceAll( "\"", "\'" ).replaceAll( "\n", "\\\\n" ); // fix for newlines in graphviz
+           // fix for newlines in graphviz
+          return Util.wrapWord(object.toString().replaceAll( "\"", "\'" ).replaceAll( "\n", "\\\\n" ));
           }
         }
       );

--- a/cascading-core/src/main/java/cascading/pipe/Operator.java
+++ b/cascading-core/src/main/java/cascading/pipe/Operator.java
@@ -406,7 +406,7 @@ public abstract class Operator extends Pipe
   protected void printInternal( StringBuffer buffer, Scope scope )
     {
     super.printInternal( buffer, scope );
-    buffer.append( "[" );
+    buffer.append( " [" );
     BaseOperation.printOperationInternal( operation, buffer, scope );
     buffer.append( "]" );
     }

--- a/cascading-core/src/main/java/cascading/pipe/Splice.java
+++ b/cascading-core/src/main/java/cascading/pipe/Splice.java
@@ -1288,7 +1288,7 @@ public class Splice extends Pipe
 
     if( map != null )
       {
-      buffer.append( "[by:" );
+      buffer.append( " [by:" );
 
       // important to retain incoming pipe order
       for( Map.Entry<String, Fields> entry : keyFieldsMap.entrySet() )

--- a/cascading-core/src/main/java/cascading/scheme/Scheme.java
+++ b/cascading-core/src/main/java/cascading/scheme/Scheme.java
@@ -452,7 +452,7 @@ public abstract class Scheme<Config, Input, Output, SourceContext, SinkContext> 
     if( getSinkFields().equals( getSourceFields() ) )
       return getClass().getSimpleName() + "[" + getSourceFields().print() + "]";
     else
-      return getClass().getSimpleName() + "[" + getSourceFields().print() + "->" + getSinkFields().print() + "]";
+      return getClass().getSimpleName() + "[" + getSourceFields().print() + " ->" + getSinkFields().print() + "]";
     }
 
   public int hashCode()

--- a/cascading-core/src/main/java/cascading/tap/Tap.java
+++ b/cascading-core/src/main/java/cascading/tap/Tap.java
@@ -672,8 +672,8 @@ public abstract class Tap<Config, Input, Output> implements FlowElement, Seriali
   public String toString()
     {
     if( getIdentifier() != null )
-      return getClass().getSimpleName() + "[\"" + getScheme() + "\"]" + "[\"" + Util.sanitizeUrl( getIdentifier() ) + "\"]"; // sanitize
+      return getClass().getSimpleName() + "[\"" + getScheme() + "\"] " + "[\"" + Util.sanitizeUrl( getIdentifier() ) + "\"]"; // sanitize
     else
-      return getClass().getSimpleName() + "[\"" + getScheme() + "\"]" + "[not initialized]";
+      return getClass().getSimpleName() + "[\"" + getScheme() + "\"] " + "[not initialized]";
     }
   }

--- a/cascading-core/src/main/java/cascading/util/Util.java
+++ b/cascading-core/src/main/java/cascading/util/Util.java
@@ -46,6 +46,7 @@ import cascading.pipe.Pipe;
 import cascading.scheme.Scheme;
 import cascading.tap.MultiSourceTap;
 import cascading.tap.Tap;
+import org.apache.commons.lang.WordUtils;
 import org.jgrapht.ext.DOTExporter;
 import org.jgrapht.ext.EdgeNameProvider;
 import org.jgrapht.ext.IntegerNameProvider;
@@ -529,6 +530,17 @@ public class Util
   public static void writeDOT( Writer writer, SimpleDirectedGraph graph, IntegerNameProvider vertexIdProvider, VertexNameProvider vertexNameProvider, EdgeNameProvider edgeNameProvider )
     {
     new DOTExporter( vertexIdProvider, vertexNameProvider, edgeNameProvider ).export( writer, graph );
+    }
+
+  /**
+   * Method wrapWord inserts a '\n' to the line of text written to DOT
+   *
+   * @param str    the string to wrap
+   * @return String
+   */
+  public static String wrapWord(String str)
+    {
+    return WordUtils.wrap(str, 50, "\\n", false);
     }
 
   public static boolean isEmpty( String string )


### PR DESCRIPTION
Hi, 

I'd like to send a pull request about enhancement of DOT print. Current implementation of DOT output is OK if the Fields length is small (only several fields are defined in the schemes). But if there are many fields being used (in real cases, the data warehouse tables often hold hundreds of columns), that will make the graph very wide (but short). It's not easy to view, even with a wide screen.

Appropriately insert some "\n" to DOT file can make the graph slim and tall, much easier to view.  

Thanks,
Branky

![old](https://f.cloud.github.com/assets/614116/242697/90dfeda8-8a26-11e2-8ede-d9d1edef452e.jpg)

![new](https://f.cloud.github.com/assets/614116/242698/a8649834-8a26-11e2-971d-0665bb58380c.jpeg)
