### PR TITLE
Scheme does not  format output if all columns are filtered

### DIFF
--- a/cascading-core/src/main/java/cascading/tap/MultiSinkTap.java
+++ b/cascading-core/src/main/java/cascading/tap/MultiSinkTap.java
@@ -77,6 +77,11 @@ public class MultiSinkTap<Child extends Tap, Config, Output> extends SinkTap<Con
         LOG.info( "opening for write: {}", tap.toString() );
 
         collectors[ i ] = tap.openForWrite( flowProcess.copyWith( mergedConf ), null );
+        if( tap.getSinkFields().isAll() )
+          {
+          Fields fields = getSinkFields();
+          collectors[ i ].setFields( fields );
+          }
         }
       }
 
@@ -247,13 +252,19 @@ public class MultiSinkTap<Child extends Tap, Config, Output> extends SinkTap<Con
 
     Set<Comparable> fieldNames = new LinkedHashSet<Comparable>();
 
+    boolean useAll = false;
     for( int i = 0; i < getTaps().length; i++ )
       {
-      for( Object o : getTaps()[ i ].getSinkFields() )
+      Fields fields = getTaps()[ i ].getSinkFields();
+      if ( fields.isAll() ) {
+        useAll = true;
+        break;
+      }
+      for( Object o : fields )
         fieldNames.add( (Comparable) o );
       }
 
-    Fields allFields = new Fields( fieldNames.toArray( new Comparable[ fieldNames.size() ] ) );
+    Fields allFields = useAll ? Fields.ALL : new Fields( fieldNames.toArray( new Comparable[ fieldNames.size() ] ) );
 
     setScheme( new NullScheme( allFields, allFields ) );
 

--- a/cascading-core/src/main/java/cascading/tuple/TupleEntrySchemeCollector.java
+++ b/cascading-core/src/main/java/cascading/tuple/TupleEntrySchemeCollector.java
@@ -171,6 +171,8 @@ public class TupleEntrySchemeCollector<Config, Output> extends TupleEntryCollect
 
       try
         {
+        if( !prepared && tupleEntry != null )
+          prepare();
         if( prepared )
           scheme.sinkCleanup( flowProcess, sinkCall );
         }


### PR DESCRIPTION
Fix a bug in Cascading such that a Sink Destination does not get written out with its proper Scheme definition IF the source to that Tap does not stream data to it. For example, if you apply a filter that filters out all of the data, then the resultant Sink would not see any data, and thus never gets "prepared".

In the case of the FileTap, this means that an empty file would be create, even if you request that the Scheme include a header. This change makes it at least write the header, such that future parses of that resultant file do not fail.
