### PR TITLE
Detect missing input format when MultiInputFormat is used

### DIFF
--- a/cascading-hadoop/src/main/java/cascading/tap/hadoop/io/MultiInputFormat.java
+++ b/cascading-hadoop/src/main/java/cascading/tap/hadoop/io/MultiInputFormat.java
@@ -66,6 +66,12 @@ public class MultiInputFormat implements InputFormat
 
     for( JobConf fromJob : fromJobs )
       {
+      // the input jobs must have the input format set: otherwise reject it
+      if( fromJob.getClass( "mapred.input.format.class", null ) == null )
+        {
+        throw new CascadingException( "the job is missing the input format" );
+        }
+
       configs.add( HadoopUtil.getConfig( toJob, fromJob ) );
       Collections.addAll( allPaths, FileInputFormat.getInputPaths( fromJob ) );
 

--- a/cascading-hadoop/src/main/java/cascading/tap/hadoop/io/MultiInputFormat.java
+++ b/cascading-hadoop/src/main/java/cascading/tap/hadoop/io/MultiInputFormat.java
@@ -67,7 +67,7 @@ public class MultiInputFormat implements InputFormat
     for( JobConf fromJob : fromJobs )
       {
       // the input jobs must have the input format set: otherwise reject it
-      if( fromJob.getClass( "mapred.input.format.class", null ) == null )
+      if( fromJob.get( "mapred.input.format.class" ) == null )
         {
         throw new CascadingException( "the job is missing the input format" );
         }


### PR DESCRIPTION
Throw an exception if any of the underlying job confs is missing the input format.
