### PR TITLE
FileTap loses headers in MultiSinkTap 

### DIFF
--- a/cascading-core/src/main/java/cascading/flow/stream/FunctionEachStage.java
+++ b/cascading-core/src/main/java/cascading/flow/stream/FunctionEachStage.java
@@ -71,7 +71,15 @@ public class FunctionEachStage extends EachStage
     @Override
     protected void collect( TupleEntry input ) throws IOException
       {
-      Tuple outgoing = outgoingBuilder.makeResult( incomingEntry.getTuple(), input.getTuple() );
+      Tuple outgoing;
+      // In cases where the Operation introduces new tuples to a flow which has
+      // received no rows, this will avoid a nasty NPE.  It may have some
+      // assumptions on the makeResult operation though.
+      if ( incomingEntry == null ) {
+        outgoing = outgoingBuilder.makeResult( input.getTuple(), input.getTuple() );
+      } else {
+        outgoing = outgoingBuilder.makeResult( incomingEntry.getTuple(), input.getTuple() );
+      }
 
       outgoingEntry.setTuple( outgoing );
 

--- a/cascading-core/src/main/java/cascading/scheme/util/DelimitedParser.java
+++ b/cascading-core/src/main/java/cascading/scheme/util/DelimitedParser.java
@@ -367,7 +367,7 @@ public class DelimitedParser implements Serializable
         if( valueString.contains( quote ) )
           valueString = valueString.replaceAll( quote, quote + quote );
 
-        if( valueString.contains( delimiter ) )
+        if( valueString.contains( delimiter ) || valueString.contains( "\n" ) )
           valueString = quote + valueString + quote;
 
         buffer.append( valueString );

--- a/cascading-core/src/main/java/cascading/tap/MultiSinkTap.java
+++ b/cascading-core/src/main/java/cascading/tap/MultiSinkTap.java
@@ -77,6 +77,11 @@ public class MultiSinkTap<Child extends Tap, Config, Output> extends SinkTap<Con
         LOG.info( "opening for write: {}", tap.toString() );
 
         collectors[ i ] = tap.openForWrite( flowProcess.copyWith( mergedConf ), null );
+        if( tap.getSinkFields().isAll() )
+          {
+          Fields fields = getSinkFields();
+          collectors[ i ].setFields( fields );
+          }
         }
       }
 
@@ -247,13 +252,19 @@ public class MultiSinkTap<Child extends Tap, Config, Output> extends SinkTap<Con
 
     Set<Comparable> fieldNames = new LinkedHashSet<Comparable>();
 
+    boolean useAll = false;
     for( int i = 0; i < getTaps().length; i++ )
       {
-      for( Object o : getTaps()[ i ].getSinkFields() )
+      Fields fields = getTaps()[ i ].getSinkFields();
+      if ( fields.isAll() ) {
+        useAll = true;
+        break;
+      }
+      for( Object o : fields )
         fieldNames.add( (Comparable) o );
       }
 
-    Fields allFields = new Fields( fieldNames.toArray( new Comparable[ fieldNames.size() ] ) );
+    Fields allFields = useAll ? Fields.ALL : new Fields( fieldNames.toArray( new Comparable[ fieldNames.size() ] ) );
 
     setScheme( new NullScheme( allFields, allFields ) );
 

--- a/cascading-core/src/main/java/cascading/tap/MultiSinkTap.java
+++ b/cascading-core/src/main/java/cascading/tap/MultiSinkTap.java
@@ -283,7 +283,7 @@ public class MultiSinkTap<Child extends Tap, Config, Output> extends SinkTap<Con
       public void setSinkFields( Fields fields ) {
         Child[] taps = getTaps();
         for( int i = 0, sz = taps.length; i < sz; i++ ) {
-          taps[i].getScheme().setSourceFields( fields );
+          taps[i].getScheme().setSinkFields( fields );
         }
       }
     });

--- a/cascading-core/src/main/java/cascading/tuple/TupleEntrySchemeCollector.java
+++ b/cascading-core/src/main/java/cascading/tuple/TupleEntrySchemeCollector.java
@@ -171,6 +171,8 @@ public class TupleEntrySchemeCollector<Config, Output> extends TupleEntryCollect
 
       try
         {
+        if( !prepared && tupleEntry != null )
+          prepare();
         if( prepared )
           scheme.sinkCleanup( flowProcess, sinkCall );
         }

--- a/cascading-local/src/main/java/cascading/scheme/local/TextDelimited.java
+++ b/cascading-local/src/main/java/cascading/scheme/local/TextDelimited.java
@@ -97,7 +97,7 @@ public class TextDelimited extends Scheme<Properties, InputStream, OutputStream,
 
   private final boolean skipHeader;
   private final boolean writeHeader;
-  private final DelimitedParser delimitedParser;
+  protected final DelimitedParser delimitedParser;
   private String charsetName = DEFAULT_CHARSET;
 
   /**

--- a/cascading-local/src/main/java/cascading/tap/local/FileTap.java
+++ b/cascading-local/src/main/java/cascading/tap/local/FileTap.java
@@ -26,6 +26,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Properties;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
 
 import cascading.flow.FlowProcess;
 import cascading.scheme.Scheme;
@@ -81,8 +83,12 @@ public class FileTap extends Tap<Properties, InputStream, OutputStream>
   @Override
   public TupleEntryIterator openForRead( FlowProcess<Properties> flowProcess, InputStream input ) throws IOException
     {
-    if( input == null )
+    if( input == null ) {
       input = new FileInputStream( getIdentifier() );
+      if ( getIdentifier().toLowerCase().endsWith( ".gz" ) ) {
+        input = new GZIPInputStream( input );
+      }
+    }
 
     return new TupleEntrySchemeIterator<Properties, InputStream>( flowProcess, getScheme(), input, getIdentifier() );
     }
@@ -90,8 +96,12 @@ public class FileTap extends Tap<Properties, InputStream, OutputStream>
   @Override
   public TupleEntryCollector openForWrite( FlowProcess<Properties> flowProcess, OutputStream output ) throws IOException
     {
-    if( output == null )
+    if( output == null ) {
       output = new TapFileOutputStream( getIdentifier(), isUpdate() ); // append if we are in update mode
+      if ( getIdentifier().toLowerCase().endsWith( ".gz" ) ) {
+        output = new GZIPOutputStream( output );
+      }
+    }
 
     return new TupleEntrySchemeCollector<Properties, OutputStream>( flowProcess, getScheme(), output, getIdentifier() );
     }


### PR DESCRIPTION
I started using a MultiSinkTap earlier today, and noticed that the headers of my FileTap were missing. After some tracking it down, I was using Fields.ALL, which it appears that the MultiSinkTap getfields implementation was ignoring entirely, but even with that in place, the FileTap wasn't getting its fields set. This appears to work fine on my code. Thanks.
