### PR TITLE
2.1

### DIFF
--- a/cascading-core/src/main/java/cascading/flow/BaseFlow.java
+++ b/cascading-core/src/main/java/cascading/flow/BaseFlow.java
@@ -156,7 +156,6 @@ public abstract class BaseFlow<Config> implements Flow<Config>
     this.name = name;
     addSessionProperties( properties );
     initConfig( properties, defaultConfig );
-    initFromProperties( properties );
 
     this.flowStats = createPrepareFlowStats(); // must be last
     }

--- a/cascading-core/src/main/java/cascading/flow/BaseFlow.java
+++ b/cascading-core/src/main/java/cascading/flow/BaseFlow.java
@@ -174,7 +174,6 @@ public abstract class BaseFlow<Config> implements Flow<Config>
     setSinks( flowDef.getSinksCopy() );
     setTraps( flowDef.getTrapsCopy() );
     setCheckpoints( flowDef.getCheckpointsCopy() );
-    initFromProperties( properties );
     initFromTaps();
 
     retrieveSourceFields();

--- a/cascading-core/src/main/java/cascading/tuple/Fields.java
+++ b/cascading-core/src/main/java/cascading/tuple/Fields.java
@@ -693,6 +693,10 @@ public class Fields implements Comparable, Iterable<Comparable>, Serializable, C
     for( int i = 0; i < fields.length; i++ )
       {
       Comparable field = fields[ i ];
+      
+      if (!(field instanceof String || field instanceof Integer )) {
+        throw new IllegalArgumentException( String.format( "invalid field type (%s); must be String or Integer: ", field ));
+      }
 
       if( field == null )
         throw new IllegalArgumentException( "field name or position may not be null" );

--- a/cascading-hadoop/src/main/java/cascading/flow/hadoop/HadoopFlow.java
+++ b/cascading-hadoop/src/main/java/cascading/flow/hadoop/HadoopFlow.java
@@ -81,6 +81,7 @@ public class HadoopFlow extends BaseFlow<JobConf>
   protected HadoopFlow( PlatformInfo platformInfo, Map<Object, Object> properties, JobConf jobConf, String name )
     {
     super( platformInfo, properties, jobConf, name );
+    initFromProperties(properties);
     }
 
   public HadoopFlow( PlatformInfo platformInfo, Map<Object, Object> properties, JobConf jobConf, FlowDef flowDef )

--- a/cascading-hadoop/src/main/java/cascading/flow/hadoop/HadoopFlow.java
+++ b/cascading-hadoop/src/main/java/cascading/flow/hadoop/HadoopFlow.java
@@ -87,6 +87,7 @@ public class HadoopFlow extends BaseFlow<JobConf>
   public HadoopFlow( PlatformInfo platformInfo, Map<Object, Object> properties, JobConf jobConf, FlowDef flowDef )
     {
     super( platformInfo, properties, jobConf, flowDef );
+    initFromProperties(properties);
     }
 
   protected void initFromProperties( Map<Object, Object> properties )

--- a/cascading-local/src/main/java/cascading/flow/local/LocalFlow.java
+++ b/cascading-local/src/main/java/cascading/flow/local/LocalFlow.java
@@ -44,6 +44,7 @@ public class LocalFlow extends BaseFlow<Properties>
   public LocalFlow( PlatformInfo platformInfo, Map<Object, Object> properties, Properties config, FlowDef flowDef )
     {
     super( platformInfo, properties, config, flowDef );
+    initFromProperties(properties);
     }
 
   @Override


### PR DESCRIPTION
Two changes.

1.) Change so that initialization in base class BaseFlow does not get overriden in subclasses HadoopFlow and LocalFlow. See HadoopFlow.preserveTemporaryFiles in particular.

2.) Throw exception if type of Comaparable in Fields is other than Integer or String. Not sure about this one, but, after all, you are trying to cast to Integer below, which will cause a ClassCastException if Comparable is like a float. Nit.
