### PR TITLE
Fall back to TuplePartitioner when no other Partitioner is called for

### DIFF
--- a/cascading-hadoop/src/main/shared/cascading/flow/hadoop/HadoopFlowStep.java
+++ b/cascading-hadoop/src/main/shared/cascading/flow/hadoop/HadoopFlowStep.java
@@ -52,6 +52,7 @@ import cascading.tuple.hadoop.util.IndexTupleCoGroupingComparator;
 import cascading.tuple.hadoop.util.ReverseGroupingSortingComparator;
 import cascading.tuple.hadoop.util.ReverseTupleComparator;
 import cascading.tuple.hadoop.util.TupleComparator;
+import cascading.tuple.hadoop.util.TuplePartitioner;
 import cascading.tuple.io.IndexTuple;
 import cascading.tuple.io.TuplePair;
 import cascading.util.Util;
@@ -124,6 +125,7 @@ public class HadoopFlowStep extends BaseFlowStep<JobConf>
       // must set map output defaults when performing a reduce
       conf.setMapOutputKeyClass( Tuple.class );
       conf.setMapOutputValueClass( Tuple.class );
+      conf.setPartitionerClass( TuplePartitioner.class );
 
       // handles the case the groupby sort should be reversed
       if( getGroup().isSortReversed() )

--- a/cascading-hadoop/src/main/shared/cascading/tuple/hadoop/util/TuplePartitioner.java
+++ b/cascading-hadoop/src/main/shared/cascading/tuple/hadoop/util/TuplePartitioner.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2007-2013 Concurrent, Inc. All Rights Reserved.
+ *
+ * Project and contact information: http://www.cascading.org/
+ *
+ * This file is part of the Cascading project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cascading.tuple.hadoop.util;
+
+import cascading.tuple.Tuple;
+import org.apache.hadoop.mapred.Partitioner;
+
+/** Class TuplePartitioner is an implementation of {@link org.apache.hadoop.mapred.Partitioner}. */
+public class TuplePartitioner extends HasherPartitioner implements Partitioner<Tuple, Tuple>
+{
+  public int getPartition( Tuple key, Tuple value, int numReduceTasks )
+  {
+    return ( hashCode( key ) & Integer.MAX_VALUE ) % numReduceTasks;
+  }
+}


### PR DESCRIPTION
Currently any custom Hashers are only used as Partitioners for CoGroups and GroupBys with a secondary sort. This patch should cause them to get used in all cases (in particular for GroupBys with no secondary sort).
