### PR TITLE
Avoid Credentials-sharing behavior of new JobConf(JobConf).

### DIFF
--- a/cascading-hadoop/src/main/shared/cascading/flow/hadoop/HadoopFlow.java
+++ b/cascading-hadoop/src/main/shared/cascading/flow/hadoop/HadoopFlow.java
@@ -115,7 +115,7 @@ public class HadoopFlow extends BaseFlow<JobConf>
     if( parentConfig == null ) // this is ok, getJobConf will pass a default parent in
       return;
 
-    jobConf = new JobConf( parentConfig ); // prevent local values from being shared
+    jobConf = HadoopUtil.copyJobConf( parentConfig ); // prevent local values from being shared
     jobConf.set( "fs.http.impl", HttpFileSystem.class.getName() );
     jobConf.set( "fs.https.impl", HttpFileSystem.class.getName() );
 
@@ -135,7 +135,7 @@ public class HadoopFlow extends BaseFlow<JobConf>
   @Override
   protected JobConf newConfig( JobConf defaultConfig )
     {
-    return defaultConfig == null ? new JobConf() : new JobConf( defaultConfig );
+    return defaultConfig == null ? new JobConf() : HadoopUtil.copyJobConf( defaultConfig );
     }
 
   @Override
@@ -150,7 +150,7 @@ public class HadoopFlow extends BaseFlow<JobConf>
   @Override
   public JobConf getConfigCopy()
     {
-    return new JobConf( getConfig() );
+    return HadoopUtil.copyJobConf( getConfig() );
     }
 
   @Override

--- a/cascading-hadoop/src/main/shared/cascading/flow/hadoop/HadoopFlowProcess.java
+++ b/cascading-hadoop/src/main/shared/cascading/flow/hadoop/HadoopFlowProcess.java
@@ -121,7 +121,7 @@ public class HadoopFlowProcess extends FlowProcess<JobConf>
   @Override
   public JobConf getConfigCopy()
     {
-    return new JobConf( jobConf );
+    return HadoopUtil.copyJobConf( jobConf );
     }
 
   /**
@@ -274,7 +274,7 @@ public class HadoopFlowProcess extends FlowProcess<JobConf>
   @Override
   public TupleEntryCollector openTrapForWrite( Tap trap ) throws IOException
     {
-    JobConf jobConf = new JobConf( getJobConf() );
+    JobConf jobConf = HadoopUtil.copyJobConf( getJobConf() );
 
     int stepNum = jobConf.getInt( "cascading.flow.step.num", 0 );
     String partname;
@@ -312,7 +312,7 @@ public class HadoopFlowProcess extends FlowProcess<JobConf>
   @Override
   public JobConf copyConfig( JobConf jobConf )
     {
-    return new JobConf( jobConf );
+    return HadoopUtil.copyJobConf( jobConf );
     }
 
   @Override

--- a/cascading-hadoop/src/main/shared/cascading/flow/hadoop/HadoopFlowStep.java
+++ b/cascading-hadoop/src/main/shared/cascading/flow/hadoop/HadoopFlowStep.java
@@ -80,7 +80,7 @@ public class HadoopFlowStep extends BaseFlowStep<JobConf>
 
   public JobConf getInitializedConfig( FlowProcess<JobConf> flowProcess, JobConf parentConfig )
     {
-    JobConf conf = parentConfig == null ? new JobConf() : new JobConf( parentConfig );
+    JobConf conf = parentConfig == null ? new JobConf() : HadoopUtil.copyJobConf( parentConfig );
 
     // disable warning
     conf.setBoolean( "mapred.used.genericoptionsparser", true );
@@ -305,7 +305,7 @@ public class HadoopFlowStep extends BaseFlowStep<JobConf>
     {
     if( !traps.isEmpty() )
       {
-      JobConf trapConf = new JobConf( conf );
+      JobConf trapConf = HadoopUtil.copyJobConf( conf );
 
       for( Tap tap : traps.values() )
         tap.sinkConfInit( flowProcess, trapConf );


### PR DESCRIPTION
The JobConf(JobConf) constructor causes derived JobConfs to share Credentials. In hadoop 2.3, at least, during job submission the Credentials are mutated (a shuffle token is added). This happens in separate threads on the same underlying Credentials instance, which is not thread-safe and so the instance can become corrupted.

This patch works around the problem by tricking the JobConf constructor into not copying the Credentials reference (by passing it a Configuration that is not a JobConf) and then manually copying the Credentials.
