### PR TITLE
Roboustness: current version crashed if any of the read gzip files are currupt (EOF Exception) 

### DIFF
--- a/cascading-core/src/main/java/cascading/tuple/TupleEntrySchemeIterator.java
+++ b/cascading-core/src/main/java/cascading/tuple/TupleEntrySchemeIterator.java
@@ -21,184 +21,176 @@
 package cascading.tuple;
 
 import java.io.Closeable;
+import java.io.EOFException;
 import java.io.IOException;
 
 import cascading.flow.FlowProcess;
+
 import cascading.scheme.ConcreteCall;
 import cascading.scheme.Scheme;
+
 import cascading.util.CloseableIterator;
 import cascading.util.SingleCloseableInputIterator;
 
 /**
  * Class TupleEntrySchemeIterator is a helper class for wrapping a {@link Scheme} instance, calling
- * {@link Scheme#source(cascading.flow.FlowProcess, cascading.scheme.SourceCall)} on every call to
- * {@link #next()}.
- * <p/>
- * Use this class inside a custom {@link cascading.tap.Tap} when overriding the
+ * {@link Scheme#source(cascading.flow.FlowProcess, cascading.scheme.SourceCall)} on every call to {@link #next()}.
+ *
+ * <p/>Use this class inside a custom {@link cascading.tap.Tap} when overriding the
  * {@link cascading.tap.Tap#openForRead(cascading.flow.FlowProcess)} method.
  */
-public class TupleEntrySchemeIterator<Config, Input> extends TupleEntryIterator
-  {
-  private final FlowProcess<Config> flowProcess;
-  private final Scheme scheme;
-  private final CloseableIterator<Input> inputIterator;
-  private ConcreteCall sourceCall;
+public class TupleEntrySchemeIterator<Config, Input> extends TupleEntryIterator {
+    private final FlowProcess<Config> flowProcess;
+    private final Scheme scheme;
+    private final CloseableIterator<Input> inputIterator;
+    private ConcreteCall sourceCall;
 
-  private String identifier;
-  private boolean isComplete = false;
-  private boolean hasWaiting = false;
-  private TupleException currentException;
+    private String identifier;
+    private boolean isComplete = false;
+    private boolean hasWaiting = false;
+    private TupleException currentException;
 
-  public TupleEntrySchemeIterator( FlowProcess<Config> flowProcess, Scheme scheme, Input input )
-    {
-    this( flowProcess, scheme, input, null );
+    public TupleEntrySchemeIterator(final FlowProcess<Config> flowProcess, final Scheme scheme, final Input input) {
+        this(flowProcess, scheme, input, null);
     }
 
-  public TupleEntrySchemeIterator( FlowProcess<Config> flowProcess, Scheme scheme, Input input, String identifier )
-    {
-    this( flowProcess, scheme, (CloseableIterator<Input>) new SingleCloseableInputIterator( (Closeable) input ), identifier );
+    public TupleEntrySchemeIterator(final FlowProcess<Config> flowProcess, final Scheme scheme, final Input input,
+            final String identifier) {
+        this(flowProcess, scheme, (CloseableIterator<Input>) new SingleCloseableInputIterator((Closeable) input),
+            identifier);
     }
 
-  public TupleEntrySchemeIterator( FlowProcess<Config> flowProcess, Scheme scheme, CloseableIterator<Input> inputIterator )
-    {
-    this( flowProcess, scheme, inputIterator, null );
+    public TupleEntrySchemeIterator(final FlowProcess<Config> flowProcess, final Scheme scheme,
+            final CloseableIterator<Input> inputIterator) {
+        this(flowProcess, scheme, inputIterator, null);
     }
 
-  public TupleEntrySchemeIterator( FlowProcess<Config> flowProcess, Scheme scheme, CloseableIterator<Input> inputIterator, String identifier )
-    {
-    super( scheme.getSourceFields() );
-    this.flowProcess = flowProcess;
-    this.scheme = scheme;
-    this.inputIterator = inputIterator;
-    this.identifier = identifier;
+    public TupleEntrySchemeIterator(final FlowProcess<Config> flowProcess, final Scheme scheme,
+            final CloseableIterator<Input> inputIterator, final String identifier) {
+        super(scheme.getSourceFields());
+        this.flowProcess = flowProcess;
+        this.scheme = scheme;
+        this.inputIterator = inputIterator;
+        this.identifier = identifier;
 
-    if( this.identifier == null || this.identifier.isEmpty() )
-      this.identifier = "'unknown'";
+        if (this.identifier == null || this.identifier.isEmpty()) {
+            this.identifier = "'unknown'";
+        }
 
-    if( !inputIterator.hasNext() )
-      {
-      isComplete = true;
-      return;
-      }
+        if (!inputIterator.hasNext()) {
+            isComplete = true;
+            return;
+        }
 
-    sourceCall = new ConcreteCall();
+        sourceCall = new ConcreteCall();
 
-    sourceCall.setIncomingEntry( getTupleEntry() );
-    sourceCall.setInput( wrapInput( inputIterator.next() ) );
+        sourceCall.setIncomingEntry(getTupleEntry());
+        sourceCall.setInput(wrapInput(inputIterator.next()));
 
-    try
-      {
-      this.scheme.sourcePrepare( flowProcess, sourceCall );
-      }
-    catch( IOException exception )
-      {
-      throw new TupleException( "unable to prepare source for input identifier: " + this.identifier, exception );
-      }
+        try {
+            this.scheme.sourcePrepare(flowProcess, sourceCall);
+        } catch (IOException exception) {
+            throw new TupleException("unable to prepare source for input identifier: " + this.identifier, exception);
+        }
     }
 
-  protected FlowProcess<Config> getFlowProcess()
-    {
-    return flowProcess;
+    protected FlowProcess<Config> getFlowProcess() {
+        return flowProcess;
     }
 
-  protected Input wrapInput( Input input )
-    {
-    return input;
+    protected Input wrapInput(final Input input) {
+        return input;
     }
 
-  @Override
-  public boolean hasNext()
-    {
-    if( isComplete )
-      return false;
+    @Override
+    public boolean hasNext() {
+        if (isComplete) {
+            return false;
+        }
 
-    if( hasWaiting )
-      return true;
+        if (hasWaiting) {
+            return true;
+        }
 
-    try
-      {
-      getNext();
-      }
-    catch( Exception exception )
-      {
-      if( identifier == null || identifier.isEmpty() )
-        identifier = "'unknown'";
+        try {
+            getNext();
+        } catch (Exception exception) {
+            if (identifier == null || identifier.isEmpty()) {
+                identifier = "'unknown'";
+            }
 
-      currentException = new TupleException( "unable to read from input identifier: " + identifier, exception );
-      return true;
-      }
+            String message;
+            if (exception instanceof EOFException) {
+                message = "Unexpected end of file" + identifier + ", will closing file now";
+                isComplete = true;
+            } else {
+                message = "unable to read from input identifier: " + identifier;
+            }
 
-    if( !hasWaiting )
-      isComplete = true;
+            currentException = new TupleException(message, exception);
+            return true;
+        }
 
-    return !isComplete;
+        if (!hasWaiting) {
+            isComplete = true;
+        }
+
+        return !isComplete;
     }
 
-  private TupleEntry getNext() throws IOException
-    {
-    Tuples.asModifiable( sourceCall.getIncomingEntry().getTuple() );
-    hasWaiting = scheme.source( flowProcess, sourceCall );
+    private TupleEntry getNext() throws IOException {
+        Tuples.asModifiable(sourceCall.getIncomingEntry().getTuple());
+        hasWaiting = scheme.source(flowProcess, sourceCall);
 
-    if( !hasWaiting && inputIterator.hasNext() )
-      {
-      sourceCall.setInput( wrapInput( inputIterator.next() ) );
+        if (!hasWaiting && inputIterator.hasNext()) {
+            sourceCall.setInput(wrapInput(inputIterator.next()));
 
-      return getNext();
-      }
+            return getNext();
+        }
 
-    return getTupleEntry();
-    }
-
-  @Override
-  public TupleEntry next()
-    {
-    try
-      {
-      if( currentException != null )
-        throw currentException;
-      }
-    finally
-      {
-      currentException = null; // data may be trapped
-      }
-
-    if( isComplete )
-      throw new IllegalStateException( "no next element" );
-
-    try
-      {
-      if( hasWaiting )
         return getTupleEntry();
-
-      return getNext();
-      }
-    catch( Exception exception )
-      {
-      throw new TupleException( "unable to source from input identifier: " + identifier, exception );
-      }
-    finally
-      {
-      hasWaiting = false;
-      }
     }
 
-  @Override
-  public void remove()
-    {
-    throw new UnsupportedOperationException( "may not remove elements from this iterator" );
+    @Override
+    public TupleEntry next() {
+        try {
+            if (currentException != null) {
+                throw currentException;
+            }
+        } finally {
+            currentException = null; // data may be trapped
+        }
+
+        if (isComplete) {
+            throw new IllegalStateException("no next element");
+        }
+
+        try {
+            if (hasWaiting) {
+                return getTupleEntry();
+            }
+
+            return getNext();
+        } catch (Exception exception) {
+            throw new TupleException("unable to source from input identifier: " + identifier, exception);
+        } finally {
+            hasWaiting = false;
+        }
     }
 
-  @Override
-  public void close() throws IOException
-    {
-    try
-      {
-      if( sourceCall != null )
-        scheme.sourceCleanup( flowProcess, sourceCall );
-      }
-    finally
-      {
-      inputIterator.close();
-      }
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException("may not remove elements from this iterator");
     }
-  }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            if (sourceCall != null) {
+                scheme.sourceCleanup(flowProcess, sourceCall);
+            }
+        } finally {
+            inputIterator.close();
+        }
+    }
+}


### PR DESCRIPTION
proposed solution: traphandler catches Unexpected End of File Exception so the job does not crash when encountering such a file. In tupleentryschemeiterator mark the file as complete (no further lines, file is closed properly)
