### PR TITLE
correct Typo error

### DIFF
--- a/cascading-core/src/main/java/cascading/tuple/Fields.java
+++ b/cascading-core/src/main/java/cascading/tuple/Fields.java
@@ -1492,7 +1492,7 @@ public class Fields implements Comparable, Iterable<Comparable>, Serializable, C
     }
 
   /**
-   * Method printLong returns a String representation of this instance along with the size.
+   * Method printVerbose returns a String representation of this instance along with the size.
    *
    * @return String
    */


### PR DESCRIPTION
There was a typo error in doc comment for `printVerbose()` function
