### PR TITLE
prevent job crash in case of currupt gzip files

### DIFF
--- a/cascading-core/src/main/java/cascading/flow/stream/TrapHandler.java
+++ b/cascading-core/src/main/java/cascading/flow/stream/TrapHandler.java
@@ -21,6 +21,7 @@
 package cascading.flow.stream;
 
 import java.io.IOException;
+import java.io.EOFException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -121,6 +122,11 @@ public class TrapHandler
 
     if( cause instanceof OutOfMemoryError )
       handleReThrowableException( "caught OutOfMemoryException, will not trap, rethrowing", cause );
+
+    if (throwable.getCause() instanceof EOFException) {
+        LOG.warn("exception trap on branch: '" + trapName + ", unexpected end of file", throwable);
+        return;
+    }
 
     if( trap == null )
       handleReThrowableException( "caught Throwable, no trap available, rethrowing", throwable );

--- a/cascading-core/src/main/java/cascading/tuple/TupleEntrySchemeIterator.java
+++ b/cascading-core/src/main/java/cascading/tuple/TupleEntrySchemeIterator.java
@@ -22,6 +22,7 @@ package cascading.tuple;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.io.EOFException;
 
 import cascading.flow.FlowProcess;
 import cascading.scheme.ConcreteCall;
@@ -124,7 +125,14 @@ public class TupleEntrySchemeIterator<Config, Input> extends TupleEntryIterator
       if( identifier == null || identifier.isEmpty() )
         identifier = "'unknown'";
 
-      currentException = new TupleException( "unable to read from input identifier: " + identifier, exception );
+      String message;
+      if (exception instanceof EOFException) {
+          message = "Unexpected end of file" + identifier + ", will closing file now";
+          isComplete = true;
+      } else {
+          message = "unable to read from input identifier: " + identifier;
+      }
+      currentException = new TupleException( message, exception );
       return true;
       }
 


### PR DESCRIPTION
without reformat.

By putting the if in the traphandler before the trap==null check it should now also work without a configured trap.

My solution might be too tailored. I like the idea to catch a broader range of corruptness in files with an own exception which is dealt with at a lower level.
