### PR TITLE
Return true in hasNext on TupleEntrySchemeIterator if we have exception

### DIFF
--- a/cascading-core/src/main/java/cascading/tuple/TupleEntrySchemeIterator.java
+++ b/cascading-core/src/main/java/cascading/tuple/TupleEntrySchemeIterator.java
@@ -125,6 +125,9 @@ public class TupleEntrySchemeIterator<Config, Input> extends TupleEntryIterator
   @Override
   public boolean hasNext()
     {
+    if( currentException != null )
+      return true;
+
     if( isComplete )
       return false;
 


### PR DESCRIPTION
Hey,

if we got an exception on `getNext` inside `hasNext` on `TupleEntrySchemeIterator`, we store it in `currentException`, but if we invoke again `hasNext` we will forget about it and move forward to next split. 

to keep `hasNext` persitent we need return `true` if `currentException` is not null, until user will invoke `next`.